### PR TITLE
Add scheduled reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,19 @@ These are the commands you can interact with using the Telegram bot.
 | `/Version` | Get the bot version |
 | `/LastMatch <User>` | Get user last match |
 | `/RegisterUserReports <User>` | Register user reports for the invoking channel  |
+
+## Scheduled reports
+
+Scheduled reports are events that are launched every X amount of time to perform periodic activities and their activation depends on the serverless platform where this project is deployed.
+
+The project is tested on AWS Lambda functions, but could be adapted to other types of serverless platforms by modifying the recipe for deployment without changing production code.
+
+### Post-match results
+
+It is possible to receive the results of a match as soon as it is over on the desired channels.
+
+To do this, we must first register the user whose post-match results we want to receive using the `/RegisterUserReports <User>` command from one or more groups.
+
+If we want to disable this functionality we just need to remove the `schedule` block corresponding to the `/ReportLastMatches` command from [serverless.yml](./serverless.yml).
+
+To modify the frequency for checking if there is new information of finished matches just modify the `rate` attribute.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warzone-tracker",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "GPL-3.0",
   "description": "",
   "repository": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -35,3 +35,10 @@ functions:
           path: warzone-tracker
           method: post
           cors: true
+          input:
+            functionEventType: 'telegram'
+      - schedule:
+          rate: rate(1 minutes)
+          enabled: true
+          input:
+            functionEventType: 'scheduled'

--- a/serverless.yml
+++ b/serverless.yml
@@ -35,10 +35,8 @@ functions:
           path: warzone-tracker
           method: post
           cors: true
-          input:
-            functionEventType: 'telegram'
       - schedule:
-          rate: rate(1 minutes)
+          rate: rate(1 minute)
           enabled: true
           input:
-            functionEventType: 'scheduled'
+            scheduleCommand: '/ReportLastMatches'

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -12,16 +12,16 @@ async function processTelegramEvent(event: any): Promise<any> {
     : 'Unprocessed message'
 }
 
-async function processScheduledEvent(): Promise<any> {
-  const commandRequest = { command: '/ReportLastMatches' }
+async function processScheduledEvent(event: { scheduleCommand: string }): Promise<any> {
+  const commandRequest = { command: event.scheduleCommand }
   return await new ScheduledCommandDispatcher().dispatch(commandRequest)
 }
 
 const handle: APIGatewayProxyHandler = async (event: any): Promise<any> => {
   try {
-    const response = event.functionEventType == 'telegram'
+    const response = event.scheduleCommand == undefined
       ? await processTelegramEvent(event)
-      : await processScheduledEvent()
+      : await processScheduledEvent(event)
     return {
       body: JSON.stringify(response),
       statusCode: 200,

--- a/src/models/types/UserReportsDoc.ts
+++ b/src/models/types/UserReportsDoc.ts
@@ -1,7 +1,6 @@
 import mongoose from 'mongoose'
 
 export interface UserReportsDoc extends mongoose.Document {
-  [x: string]: any;
   user: { type: string, trim: true, unique: true, sparse: true },
   channels: [{ type: number, trim: true, sparse: true }],
   lastMatch: { type: string, trim: true, sparse: true },

--- a/src/modules/codAPIHandler/codAPIHandler.ts
+++ b/src/modules/codAPIHandler/codAPIHandler.ts
@@ -5,7 +5,7 @@ import { TitleIdentity } from './types/TitleIdentity'
 import { assertValidResponse, sendRequest, sendUserRequest } from './utils'
 
 class CoDAPIHandler {
-  async IsValidSSO(allowedUser: string, ssoToken: string): Promise<boolean> {
+  async isValidSSO(allowedUser: string, ssoToken: string): Promise<boolean> {
     const response = await sendRequest(ssoToken, { route: IdentitiesRequest })
     assertValidResponse(response)
 
@@ -16,7 +16,7 @@ class CoDAPIHandler {
     return userEntries.length > 0
   }
 
-  async GetLastMatchId(ssoToken: string, user: string): Promise<string> {
+  async getLastMatchId(ssoToken: string, user: string): Promise<string> {
     const response = await sendUserRequest(ssoToken, user, MatchesRequest)
     assertValidResponse(response)
 
@@ -30,7 +30,7 @@ class CoDAPIHandler {
     return lastMatch.matchID
   }
 
-  async GetMatchInfo(sso: string, user: string, matchId: string): Promise<PlayerMatch[]> {
+  async getMatchInfo(sso: string, user: string, matchId: string): Promise<PlayerMatch[]> {
     const lastMatchInfo = await sendRequest(sso, {
       route: MatchPlayersRequest,
       matchId: matchId,
@@ -41,7 +41,7 @@ class CoDAPIHandler {
     return lastMatchInfo.data.allPlayers as PlayerMatch[]
   }
 
-  async GetUserSummary(user: string, sso: string): Promise<APIResponse> {
+  async getUserSummary(user: string, sso: string): Promise<APIResponse> {
     const response = await sendUserRequest(sso, user, UserInfoRequest)
     assertValidResponse(response)
     return response

--- a/src/modules/codAPIHandler/utils.ts
+++ b/src/modules/codAPIHandler/utils.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { APIResponse } from './types/APIResponse'
 import { Platform } from './types/Platform'
 import { RequestProperties } from './types/RequestProperties'
-import { IdTypeVar, MatchesRequest, MatchIdVar, PlatformVar, UserTagVar } from './apiPaths'
+import { IdTypeVar, MatchIdVar, PlatformVar, UserTagVar } from './apiPaths'
 import { dbHandler } from '../dbHandler/dbHandler'
 
 const codApi = 'https://my.callofduty.com/api/papi-client'

--- a/src/modules/codAPIHandler/utils.ts
+++ b/src/modules/codAPIHandler/utils.ts
@@ -113,18 +113,4 @@ async function sendRequest(ssoToken:string, requestProperties: RequestProperties
   return { ... data, requestProperties: requestProperties }
 }
 
-async function getLastMatch(ssoToken: string, user: string): Promise<string> {
-  const response = await sendUserRequest(ssoToken, user, MatchesRequest)
-  assertValidResponse(response)
-
-  if (response.data.matches === undefined) {
-    throw new Error(response.data.message)
-  }
-
-  const lastMatch = response.data.matches
-    .sort((x, y) => y.utcStartSeconds - x.utcStartSeconds)[0]
-
-  return lastMatch.matchID
-}
-
-export { sendRequest, sendUserRequest, assertValidResponse, getLastMatch }
+export { sendRequest, sendUserRequest, assertValidResponse }

--- a/src/modules/dbHandler/dbHandler.ts
+++ b/src/modules/dbHandler/dbHandler.ts
@@ -65,6 +65,20 @@ class DbHandler {
       && userReports.channels.filter(x => x.valueOf() == channel)[0] !== undefined
   }
 
+  async updateReports(report: UserReportsDoc, lastMatch: string, lastMatchTimestamp: number): Promise<void> {
+    const updatedUserReports = {
+      lastMatch: lastMatch,
+      lastMatchTimestamp: lastMatchTimestamp,
+    }
+    await UserReportsModel.findByIdAndUpdate(report.id, updatedUserReports)
+  }
+
+  async getReports(): Promise<UserReportsDoc[]> {
+    await connectMongo()
+    const userReports = await UserReportsModel.find()
+    return userReports
+  }
+
   async getUserReports(user: string): Promise<UserReportsDoc | undefined> {
     await connectMongo()
     const userReports = await UserReportsModel.find({ user: user })

--- a/src/modules/scheduledCommands/ScheduledCommandDispatcher.ts
+++ b/src/modules/scheduledCommands/ScheduledCommandDispatcher.ts
@@ -1,0 +1,12 @@
+import { CommandDispatcher } from '../commandDispatcher/CommandDispatcher'
+import { reportLastMatchesCommand } from './commands/reportLastMatchesCommand'
+
+const commandRegex = '^/([^ ]+)'
+
+export class ScheduledCommandDispatcher extends CommandDispatcher {
+  constructor() {
+    super(commandRegex, [
+      reportLastMatchesCommand,
+    ])
+  }
+}

--- a/src/modules/scheduledCommands/commands/reportLastMatchesCommand.ts
+++ b/src/modules/scheduledCommands/commands/reportLastMatchesCommand.ts
@@ -32,14 +32,14 @@ const reportLastMatches = async (commandRequest: CommandRequest, args: string[])
   const promises = Array.from(reports, async report => {
     const user = report.user.valueOf() as string
     const lastReportedMatchId = report.lastMatch.valueOf() as string
-    const lastMatchId = await codAPIHandler.GetLastMatchId(ssoToken, user)
+    const lastMatchId = await codAPIHandler.getLastMatchId(ssoToken, user)
 
     if (lastReportedMatchId == lastMatchId) {
       console.log(`Match ${lastMatchId} already reported for ${user}`)
       return
     }
 
-    const matchInfo = await codAPIHandler.GetMatchInfo(ssoToken, user, lastMatchId)
+    const matchInfo = await codAPIHandler.getMatchInfo(ssoToken, user, lastMatchId)
     const lastMatchTimestamp = matchInfo[0].utcStartSeconds
     await dbHandler.updateReports(report, lastMatchId, lastMatchTimestamp)
 

--- a/src/modules/scheduledCommands/commands/reportLastMatchesCommand.ts
+++ b/src/modules/scheduledCommands/commands/reportLastMatchesCommand.ts
@@ -6,7 +6,7 @@ import { CommandResponse } from '../../commandDispatcher/types/CommandResponse'
 import { dbHandler } from '../../dbHandler/dbHandler'
 import { telegramFormatter } from '../../formatters/telegramFormatter'
 import { telegramSender } from '../../telegramSender/telegramSender'
-import { MissingSSOToken } from '../messages'
+import { MissingSSOToken, ScheduledReportDone } from '../messages'
 
 async function sendReportsViaTelegram(matchInfo: PlayerMatch[], user: string, channels: number[]): Promise<void> {
   const formattedMatchReport = telegramFormatter.matchReportFormatter(matchInfo, user)
@@ -50,7 +50,7 @@ const reportLastMatches = async (commandRequest: CommandRequest, args: string[])
   await Promise.allSettled(promises)
 
   return {
-    response: 'Scheduled report done',
+    response: ScheduledReportDone,
     success: true,
   }
 }

--- a/src/modules/scheduledCommands/commands/reportLastMatchesCommand.ts
+++ b/src/modules/scheduledCommands/commands/reportLastMatchesCommand.ts
@@ -1,0 +1,69 @@
+import { codAPIHandler } from '../../codAPIHandler/codAPIHandler'
+import { PlayerMatch } from '../../codAPIHandler/types/PlayerMatch'
+import { Command } from '../../commandDispatcher/types/Command'
+import { CommandRequest } from '../../commandDispatcher/types/CommandRequest'
+import { CommandResponse } from '../../commandDispatcher/types/CommandResponse'
+import { dbHandler } from '../../dbHandler/dbHandler'
+import { telegramFormatter } from '../../formatters/telegramFormatter'
+import { telegramSender } from '../../telegramSender/telegramSender'
+import { MissingSSOToken } from '../messages'
+
+async function sendReportsViaTelegram(matchInfo: PlayerMatch[], user: string, channels: number[]): Promise<void> {
+  const formattedMatchReport = telegramFormatter.matchReportFormatter(matchInfo, user)
+  const matchId = matchInfo[0].matchID
+
+  channels.forEach(async channel => {
+    console.log(`Sending Telegram report for ${user} for ${matchId} match`)
+    await telegramSender.send(channel, formattedMatchReport)
+  })
+}
+
+const reportLastMatches = async (commandRequest: CommandRequest, args: string[]): Promise<CommandResponse> => {
+  const sso = await dbHandler.getCredentials()
+  if (sso === undefined) {
+    return {
+      response: MissingSSOToken,
+      success: false,
+    }
+  }
+
+  const ssoToken = sso.ssoToken as unknown as string
+  const reports = await dbHandler.getReports()
+  const promises = Array.from(reports, async report => {
+    const user = report.user.valueOf() as string
+    const lastReportedMatchId = report.lastMatch.valueOf() as string
+    const lastMatchId = await codAPIHandler.GetLastMatchId(ssoToken, user)
+
+    if (lastReportedMatchId == lastMatchId) {
+      console.log(`Match ${lastMatchId} already reported for ${user}`)
+      return
+    }
+
+    const matchInfo = await codAPIHandler.GetMatchInfo(ssoToken, user, lastMatchId)
+    const lastMatchTimestamp = matchInfo[0].utcStartSeconds
+    await dbHandler.updateReports(report, lastMatchId, lastMatchTimestamp)
+
+    const channels = report.channels.valueOf() as number[]
+    await sendReportsViaTelegram(matchInfo, user, channels)
+  })
+
+  await Promise.allSettled(promises)
+
+  return {
+    response: 'Scheduled report done',
+    success: true,
+  }
+}
+
+function validate(args: string[]): string {
+  return 'ok'
+}
+
+class ReportLastMatchesCommand implements Command {
+  command = 'ReportLastMatches'
+  handler = reportLastMatches
+  argsValidation = validate
+}
+
+const reportLastMatchesCommand = new ReportLastMatchesCommand()
+export { reportLastMatchesCommand }

--- a/src/modules/scheduledCommands/messages.ts
+++ b/src/modules/scheduledCommands/messages.ts
@@ -1,0 +1,1 @@
+export const MissingSSOToken = 'It is necessary to register a valid SSO before using this command'

--- a/src/modules/scheduledCommands/messages.ts
+++ b/src/modules/scheduledCommands/messages.ts
@@ -1,1 +1,2 @@
 export const MissingSSOToken = 'It is necessary to register a valid SSO before using this command'
+export const ScheduledReportDone = 'Scheduled report done'

--- a/src/modules/telegramCommands/commands/lastMatchCommand.ts
+++ b/src/modules/telegramCommands/commands/lastMatchCommand.ts
@@ -20,7 +20,8 @@ const lastMatch = async (commandRequest: CommandRequest, args: string[]): Promis
   }
 
   const ssoToken = sso.ssoToken as unknown as string
-  const matchInfo = await codAPIHandler.GetLastMatchInfo(ssoToken, user)
+  const lastMatchId = await codAPIHandler.GetLastMatchId(ssoToken, user)
+  const matchInfo = await codAPIHandler.GetMatchInfo(ssoToken, user, lastMatchId)
   const formattedMatchReport = telegramFormatter.matchReportFormatter(matchInfo, user)
 
   const request = commandRequest as TelegramCommandRequest

--- a/src/modules/telegramCommands/commands/lastMatchCommand.ts
+++ b/src/modules/telegramCommands/commands/lastMatchCommand.ts
@@ -20,8 +20,8 @@ const lastMatch = async (commandRequest: CommandRequest, args: string[]): Promis
   }
 
   const ssoToken = sso.ssoToken as unknown as string
-  const lastMatchId = await codAPIHandler.GetLastMatchId(ssoToken, user)
-  const matchInfo = await codAPIHandler.GetMatchInfo(ssoToken, user, lastMatchId)
+  const lastMatchId = await codAPIHandler.getLastMatchId(ssoToken, user)
+  const matchInfo = await codAPIHandler.getMatchInfo(ssoToken, user, lastMatchId)
   const formattedMatchReport = telegramFormatter.matchReportFormatter(matchInfo, user)
 
   const request = commandRequest as TelegramCommandRequest

--- a/src/modules/telegramCommands/commands/registerUserReportsCommand.ts
+++ b/src/modules/telegramCommands/commands/registerUserReportsCommand.ts
@@ -27,7 +27,7 @@ const register = async (commandRequest: CommandRequest, args: string[]): Promise
   }
 
   const ssoToken = sso.ssoToken as unknown as string
-  const userSummary = await codAPIHandler.GetUserSummary(user, ssoToken)
+  const userSummary = await codAPIHandler.getUserSummary(user, ssoToken)
   if (userSummary === undefined) {
     return {
       response: InvalidUser,

--- a/src/modules/telegramCommands/commands/updateSSOCommand.ts
+++ b/src/modules/telegramCommands/commands/updateSSOCommand.ts
@@ -12,7 +12,7 @@ const updateSSO = async (commandRequest: CommandRequest, args: string[]): Promis
   const ssoToken = args[2]
   const allowedUser = configReader.getConfig().acceptSSOFrom
 
-  if (!await codAPIHandler.IsValidSSO(allowedUser, ssoToken)) {
+  if (!await codAPIHandler.isValidSSO(allowedUser, ssoToken)) {
     return {
       response: InvalidSSOTokenUser,
       success: false,

--- a/tests/unit/spec/modules/codAPIHandler/codAPIHandler.spec.ts
+++ b/tests/unit/spec/modules/codAPIHandler/codAPIHandler.spec.ts
@@ -17,7 +17,7 @@ describe('codAPIHandler', () => {
     jest.clearAllMocks()
   })
 
-  test('#IsValidSSO (user is not allowed)', async () => {
+  test('#isValidSSO (user is not allowed)', async () => {
     sendRequestMock.mockResolvedValueOnce({
       status: 'success',
       requestProperties: {
@@ -29,12 +29,12 @@ describe('codAPIHandler', () => {
       },
     })
 
-    const response = await codAPIHandler.IsValidSSO(testRoute, testSSO)
+    const response = await codAPIHandler.isValidSSO(testRoute, testSSO)
 
     expect(response).toBe(false)
   })
 
-  test('#IsValidSSO (user is allowed)', async () => {
+  test('#isValidSSO (user is allowed)', async () => {
     sendRequestMock.mockResolvedValueOnce({
       status: 'success',
       requestProperties: {
@@ -48,12 +48,12 @@ describe('codAPIHandler', () => {
       },
     })
 
-    const response = await codAPIHandler.IsValidSSO(testUser, testSSO)
+    const response = await codAPIHandler.isValidSSO(testUser, testSSO)
 
     expect(response).toBe(true)
   })
 
-  test('#GetMatchInfo (returns last match)', async () => {
+  test('#getMatchInfo (returns last match)', async () => {
     sendRequestMock.mockResolvedValueOnce({
       status: 'success',
       requestProperties: {
@@ -69,18 +69,18 @@ describe('codAPIHandler', () => {
       },
     })
 
-    const response = await codAPIHandler.GetMatchInfo(testSSO, testUser, 'LastMatchId')
+    const response = await codAPIHandler.getMatchInfo(testSSO, testUser, 'LastMatchId')
 
     expect(response).toStrictEqual([ { map: 'FakeMap' } ])
   })
 
-  test('#GetUserSummary', async () => {
+  test('#getUserSummary', async () => {
     sendUserRequestMock.mockResolvedValueOnce({
       status: 'success',
       fakeKey: 'fakeValue',
     } as unknown as APIResponse)
 
-    const response = await codAPIHandler.GetUserSummary(testSSO, testUser)
+    const response = await codAPIHandler.getUserSummary(testSSO, testUser)
 
     expect(response).toStrictEqual({
       status: 'success',
@@ -88,7 +88,7 @@ describe('codAPIHandler', () => {
     })
   })
 
-  test('#GetLastMatchId (returns last match)', async () => {
+  test('#getLastMatchId (returns last match)', async () => {
     sendUserRequestMock.mockResolvedValueOnce({
       status: 'success',
       data: {
@@ -109,12 +109,12 @@ describe('codAPIHandler', () => {
       },
     } as unknown as APIResponse)
 
-    const response = await codAPIHandler.GetLastMatchId(testSSO, testUser)
+    const response = await codAPIHandler.getLastMatchId(testSSO, testUser)
 
     expect(response).toBe('456')
   })
 
-  test('#GetLastMatchId (no matches found)', async () => {
+  test('#getLastMatchId (no matches found)', async () => {
     sendUserRequestMock.mockResolvedValueOnce({
       status: 'success',
       data: {
@@ -124,7 +124,7 @@ describe('codAPIHandler', () => {
     } as unknown as APIResponse)
 
     try {
-      await codAPIHandler.GetLastMatchId(testSSO, testUser)
+      await codAPIHandler.getLastMatchId(testSSO, testUser)
 
       expect(1).toBe(0)
     } catch(error: any) {

--- a/tests/unit/spec/modules/codAPIHandler/utils.spec.ts
+++ b/tests/unit/spec/modules/codAPIHandler/utils.spec.ts
@@ -3,7 +3,7 @@ import { IdTypeVar, MatchIdVar, PlatformVar, UserTagVar } from '../../../../../s
 import { APIResponse } from '../../../../../src/modules/codAPIHandler/types/APIResponse'
 import { Platform } from '../../../../../src/modules/codAPIHandler/types/Platform'
 import { PlayerMatch } from '../../../../../src/modules/codAPIHandler/types/PlayerMatch'
-import { assertValidResponse, getLastMatch, sendRequest, sendUserRequest } from '../../../../../src/modules/codAPIHandler/utils'
+import { assertValidResponse, sendRequest, sendUserRequest } from '../../../../../src/modules/codAPIHandler/utils'
 import { dbHandler } from '../../../../../src/modules/dbHandler/dbHandler'
 
 jest.mock('axios')
@@ -125,92 +125,5 @@ describe('utils', () => {
 
     expect(axios.post).toBeCalledWith(`${apiPath}FakeRoute`,
       {}, getHeaders(testSSO))
-  })
-
-  test('#GetLastMatch (no matches found)', async () => {
-    axios.post = jest.fn().mockResolvedValueOnce({
-      data: {
-        data: {
-          status: 'success',
-          requestProperties: {
-            route: testRoute,
-          },
-          data: {
-            message: 'Fake error',
-          },
-        },
-      },
-    })
-
-    try {
-      await getLastMatch(testSSO, testUser)
-
-      expect(1).toBe(0)
-    } catch(error: any) {
-      expect(error.message).toBe('Could not get the API response from FakeUser#8287')
-    }
-  })
-
-  test('#GetLastMatch (returns last match)', async () => {
-    dbHandler.getUserMetadata = jest.fn().mockResolvedValueOnce({
-      platform: 'Fake stored platform',
-    })
-    axios.post = jest.fn().mockResolvedValueOnce({
-      data: {
-        status: 'success',
-        requestProperties: {
-          route: testRoute,
-          matchId: 'Test Match',
-        },
-        data: {
-          message: '',
-          matches: [
-            {
-              utcStartSeconds: 20,
-              matchID: '123',
-            },
-            {
-              utcStartSeconds: 30,
-              matchID: '456',
-            },
-            {
-              utcStartSeconds: 10,
-              matchID: '678',
-            },
-          ] as unknown as PlayerMatch[],
-        },
-      },
-    })
-
-    const response = await getLastMatch(testSSO, testUser)
-
-    expect(response).toBe('456')
-  })
-
-  test('#GetLastMatch (unexpected match response)', async () => {
-    dbHandler.getUserMetadata = jest.fn().mockResolvedValueOnce({
-      platform: 'Fake stored platform',
-    })
-    axios.post = jest.fn().mockResolvedValueOnce({
-      data: {
-        status: 'success',
-        requestProperties: {
-          route: testRoute,
-          matchId: 'Test Match',
-        },
-        data: {
-          message: 'Fake test message',
-          matches: undefined,
-        },
-      },
-    })
-
-    try {
-      await getLastMatch(testSSO, testUser)
-
-      expect(1).toBe(0)
-    } catch(error: any) {
-      expect(error.message).toBe('Fake test message')
-    }
   })
 })

--- a/tests/unit/spec/modules/codAPIHandler/utils.spec.ts
+++ b/tests/unit/spec/modules/codAPIHandler/utils.spec.ts
@@ -2,7 +2,6 @@ import axios from 'axios'
 import { IdTypeVar, MatchIdVar, PlatformVar, UserTagVar } from '../../../../../src/modules/codAPIHandler/apiPaths'
 import { APIResponse } from '../../../../../src/modules/codAPIHandler/types/APIResponse'
 import { Platform } from '../../../../../src/modules/codAPIHandler/types/Platform'
-import { PlayerMatch } from '../../../../../src/modules/codAPIHandler/types/PlayerMatch'
 import { assertValidResponse, sendRequest, sendUserRequest } from '../../../../../src/modules/codAPIHandler/utils'
 import { dbHandler } from '../../../../../src/modules/dbHandler/dbHandler'
 

--- a/tests/unit/spec/modules/dbHandler/dbHandler.spec.ts
+++ b/tests/unit/spec/modules/dbHandler/dbHandler.spec.ts
@@ -2,6 +2,7 @@ const mockConnect = jest.fn()
 
 import mongoose from 'mongoose'
 import CredentialsModel from '../../../../../src/models/CredentialsModel'
+import { UserReportsDoc } from '../../../../../src/models/types/UserReportsDoc'
 import UserMetadataModel from '../../../../../src/models/UserMetadataModel'
 import UserReportsModel from '../../../../../src/models/UserReportsModel'
 import { dbHandler } from '../../../../../src/modules/dbHandler/dbHandler'
@@ -43,6 +44,9 @@ describe('dbHandler', () => {
   const testId = 999999
   const testSSOToken = 'TEST:SSO-TOKEN'
   const testSSOTokenExpiryDate = 'TEST:SSO-TOKEN-EXPIRYDATE'
+  const testUserReport = {
+    id: 'FakeUserId',
+  } as UserReportsDoc
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -111,6 +115,23 @@ describe('dbHandler', () => {
     await dbHandler.updateCredentials(testSSOToken)
 
     expect(CredentialsModel.findByIdAndUpdate).toBeCalled()
+  })
+
+  test('#updateReports', async () => {
+    await dbHandler.updateReports(testUserReport, 'FakeMatchId', 989)
+
+    expect(UserReportsModel.findByIdAndUpdate).toBeCalledWith(testUserReport.id, {
+      lastMatch: 'FakeMatchId',
+      lastMatchTimestamp: 989,
+    })
+  })
+
+  test('#getReports', async () => {
+    UserReportsModel.find = jest.fn().mockResolvedValue([testUserReport])
+
+    const response = await dbHandler.getReports()
+
+    expect(response).toStrictEqual([testUserReport])
   })
 
   test('#updateCredentials (credentials not found)', async () => {
@@ -182,17 +203,11 @@ describe('dbHandler', () => {
   })
 
   test('#getUserReports', async () => {
-    UserReportsModel.find = jest.fn().mockResolvedValue([{
-      id: 56789,
-      fakeKey: 'FakeValue',
-    }])
+    UserReportsModel.find = jest.fn().mockResolvedValue([testUserReport])
 
     const response = await dbHandler.getUserReports('FakeUser')
 
-    expect(response).toStrictEqual({
-      id: 56789,
-      fakeKey: 'FakeValue',
-    })
+    expect(response).toStrictEqual(testUserReport)
   })
 
   test('#registerUserReports (user not registered in any channel)', async () => {

--- a/tests/unit/spec/modules/scheduledCommands/ScheduledCommandDispatcher.spec.ts
+++ b/tests/unit/spec/modules/scheduledCommands/ScheduledCommandDispatcher.spec.ts
@@ -1,0 +1,29 @@
+import { CommandDispatcher } from '../../../../../src/modules/commandDispatcher/CommandDispatcher'
+import { ScheduledCommandDispatcher } from '../../../../../src/modules/scheduledCommands/ScheduledCommandDispatcher'
+import { reportLastMatchesCommand } from '../../../../../src/modules/scheduledCommands/commands/reportLastMatchesCommand'
+
+jest.mock('../../../../../src/modules/commandDispatcher/CommandDispatcher')
+
+jest.mock('../../../../../src/modules/configReader/configReader', () => {
+  return {
+    configReader: {
+      getConfig: jest.fn().mockReturnValue({
+        telegramBotToken: 'DUMMYTOKEN',
+      }),
+    },
+  }
+})
+
+describe('ScheduledCommandDispatcher', () => {
+  const scheduledCommandRegex = '^/([^ ]+)'
+  const scheduledCommands = [
+    reportLastMatchesCommand,
+  ]
+
+  test('Parent constructor is called using the expected commands', async () => {
+    new ScheduledCommandDispatcher()
+
+    expect(CommandDispatcher).toHaveBeenCalledTimes(1)
+    expect(CommandDispatcher).toBeCalledWith(scheduledCommandRegex, scheduledCommands)
+  })
+})

--- a/tests/unit/spec/modules/scheduledCommands/commands/reportLastMatchesCommand.spec.ts
+++ b/tests/unit/spec/modules/scheduledCommands/commands/reportLastMatchesCommand.spec.ts
@@ -25,7 +25,7 @@ jest.mock('../../../../../../src/modules/dbHandler/dbHandler', () => {
 jest.mock('../../../../../../src/modules/codAPIHandler/codAPIHandler', () => {
   return {
     codAPIHandler: {
-      GetMatchInfo: jest.fn(),
+      getMatchInfo: jest.fn(),
     },
   }
 })
@@ -82,26 +82,26 @@ describe('reportLastMatchesCommand', () => {
       user: 'FakeUser',
       lastMatch: 'FakeMatchId',
     }])
-    codAPIHandler.GetLastMatchId = jest.fn().mockResolvedValueOnce('FakeMatchId')
+    codAPIHandler.getLastMatchId = jest.fn().mockResolvedValueOnce('FakeMatchId')
 
     await reportLastMatchesCommand.handler(commandRequest, testArgs)
 
     expect(telegramSender.send).toBeCalledTimes(0)
     expect(dbHandler.updateReports).toBeCalledTimes(0)
-    expect(codAPIHandler.GetMatchInfo).toBeCalledTimes(0)
+    expect(codAPIHandler.getMatchInfo).toBeCalledTimes(0)
   })
 
   test('#handler (match not reported)', async () => {
     dbHandler.getCredentials = jest.fn().mockResolvedValueOnce(testSSO)
     dbHandler.getReports = jest.fn().mockResolvedValueOnce([fakeStoredReport])
-    codAPIHandler.GetLastMatchId = jest.fn().mockResolvedValueOnce('OldMatchId')
-    codAPIHandler.GetMatchInfo = jest.fn().mockResolvedValueOnce([{
+    codAPIHandler.getLastMatchId = jest.fn().mockResolvedValueOnce('OldMatchId')
+    codAPIHandler.getMatchInfo = jest.fn().mockResolvedValueOnce([{
       utcStartSeconds: 0,
     }])
 
     await reportLastMatchesCommand.handler(commandRequest, testArgs)
 
-    expect(codAPIHandler.GetMatchInfo).toBeCalledTimes(1)
+    expect(codAPIHandler.getMatchInfo).toBeCalledTimes(1)
     expect(dbHandler.updateReports).toBeCalledTimes(1)
     expect(telegramSender.send).toBeCalledTimes(1)
   })
@@ -113,14 +113,14 @@ describe('reportLastMatchesCommand', () => {
       fakeStoredReport,
       fakeStoredReport,
     ])
-    codAPIHandler.GetLastMatchId = jest.fn().mockResolvedValue('OldMatchId')
-    codAPIHandler.GetMatchInfo = jest.fn().mockResolvedValue([{
+    codAPIHandler.getLastMatchId = jest.fn().mockResolvedValue('OldMatchId')
+    codAPIHandler.getMatchInfo = jest.fn().mockResolvedValue([{
       utcStartSeconds: 0,
     }])
 
     await reportLastMatchesCommand.handler(commandRequest, testArgs)
 
-    expect(codAPIHandler.GetMatchInfo).toBeCalledTimes(3)
+    expect(codAPIHandler.getMatchInfo).toBeCalledTimes(3)
     expect(dbHandler.updateReports).toBeCalledTimes(3)
     expect(telegramSender.send).toBeCalledTimes(3)
   })
@@ -131,14 +131,14 @@ describe('reportLastMatchesCommand', () => {
       ... fakeStoredReport,
       channels: [ 1, 2, 3, 4, 5 ],
     }])
-    codAPIHandler.GetLastMatchId = jest.fn().mockResolvedValueOnce('OldMatchId')
-    codAPIHandler.GetMatchInfo = jest.fn().mockResolvedValueOnce([{
+    codAPIHandler.getLastMatchId = jest.fn().mockResolvedValueOnce('OldMatchId')
+    codAPIHandler.getMatchInfo = jest.fn().mockResolvedValueOnce([{
       utcStartSeconds: 0,
     }])
 
     await reportLastMatchesCommand.handler(commandRequest, testArgs)
 
-    expect(codAPIHandler.GetMatchInfo).toBeCalledTimes(1)
+    expect(codAPIHandler.getMatchInfo).toBeCalledTimes(1)
     expect(dbHandler.updateReports).toBeCalledTimes(1)
     expect(telegramSender.send).toBeCalledTimes(5)
   })

--- a/tests/unit/spec/modules/scheduledCommands/commands/reportLastMatchesCommand.spec.ts
+++ b/tests/unit/spec/modules/scheduledCommands/commands/reportLastMatchesCommand.spec.ts
@@ -1,0 +1,145 @@
+import { codAPIHandler } from '../../../../../../src/modules/codAPIHandler/codAPIHandler'
+import { dbHandler } from '../../../../../../src/modules/dbHandler/dbHandler'
+import { reportLastMatchesCommand } from '../../../../../../src/modules/scheduledCommands/commands/reportLastMatchesCommand'
+import { MissingSSOToken, ScheduledReportDone } from '../../../../../../src/modules/scheduledCommands/messages'
+import { telegramSender } from '../../../../../../src/modules/telegramSender/telegramSender'
+
+jest.mock('../../../../../../src/modules/telegramSender/telegramSender', () => {
+  return {
+    telegramSender: {
+      send: jest.fn(),
+    },
+  }
+})
+
+jest.mock('../../../../../../src/modules/formatters/telegramFormatter')
+
+jest.mock('../../../../../../src/modules/dbHandler/dbHandler', () => {
+  return {
+    dbHandler: {
+      updateReports: jest.fn(),
+    },
+  }
+})
+
+jest.mock('../../../../../../src/modules/codAPIHandler/codAPIHandler', () => {
+  return {
+    codAPIHandler: {
+      GetMatchInfo: jest.fn(),
+    },
+  }
+})
+
+describe('reportLastMatchesCommand', () => {
+  const testArgs = [ '', '', '' ]
+  const testSSO = { ssoToken: 'FakeSSO' }
+  const commandRequest = {
+    command: '/FakeCommand',
+  }
+  const fakeStoredReport = {
+    user: 'FakeUser',
+    lastMatch: 'FakeMatchId',
+    channels: [ 9 ],
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('#validate (returns ok)', async () => {
+    const response = reportLastMatchesCommand.argsValidation([])
+
+    expect(response).toBe('ok')
+  })
+
+  test('#handler (missing token)', async () => {
+    dbHandler.getCredentials = jest.fn().mockResolvedValueOnce(undefined)
+
+    const response = await reportLastMatchesCommand.handler(commandRequest, testArgs)
+
+    expect(response).toStrictEqual({
+      response: MissingSSOToken,
+      success: false,
+    })
+  })
+
+  test('#handler (no available reports)', async () => {
+    dbHandler.getCredentials = jest.fn().mockResolvedValueOnce(testSSO)
+    dbHandler.getReports = jest.fn().mockResolvedValueOnce([])
+
+    const response = await reportLastMatchesCommand.handler(commandRequest, testArgs)
+
+    expect(telegramSender.send).toBeCalledTimes(0)
+    expect(response).toStrictEqual({
+      response: ScheduledReportDone,
+      success: true,
+    })
+  })
+
+  test('#handler (match already reported)', async () => {
+    dbHandler.getCredentials = jest.fn().mockResolvedValueOnce(testSSO)
+    dbHandler.getReports = jest.fn().mockResolvedValueOnce([{
+      user: 'FakeUser',
+      lastMatch: 'FakeMatchId',
+    }])
+    codAPIHandler.GetLastMatchId = jest.fn().mockResolvedValueOnce('FakeMatchId')
+
+    await reportLastMatchesCommand.handler(commandRequest, testArgs)
+
+    expect(telegramSender.send).toBeCalledTimes(0)
+    expect(dbHandler.updateReports).toBeCalledTimes(0)
+    expect(codAPIHandler.GetMatchInfo).toBeCalledTimes(0)
+  })
+
+  test('#handler (match not reported)', async () => {
+    dbHandler.getCredentials = jest.fn().mockResolvedValueOnce(testSSO)
+    dbHandler.getReports = jest.fn().mockResolvedValueOnce([fakeStoredReport])
+    codAPIHandler.GetLastMatchId = jest.fn().mockResolvedValueOnce('OldMatchId')
+    codAPIHandler.GetMatchInfo = jest.fn().mockResolvedValueOnce([{
+      utcStartSeconds: 0,
+    }])
+
+    await reportLastMatchesCommand.handler(commandRequest, testArgs)
+
+    expect(codAPIHandler.GetMatchInfo).toBeCalledTimes(1)
+    expect(dbHandler.updateReports).toBeCalledTimes(1)
+    expect(telegramSender.send).toBeCalledTimes(1)
+  })
+
+  test('#handler (process reports for several users)', async () => {
+    dbHandler.getCredentials = jest.fn().mockResolvedValueOnce(testSSO)
+    dbHandler.getReports = jest.fn().mockResolvedValueOnce([
+      fakeStoredReport,
+      fakeStoredReport,
+      fakeStoredReport,
+    ])
+    codAPIHandler.GetLastMatchId = jest.fn().mockResolvedValue('OldMatchId')
+    codAPIHandler.GetMatchInfo = jest.fn().mockResolvedValue([{
+      utcStartSeconds: 0,
+    }])
+
+    await reportLastMatchesCommand.handler(commandRequest, testArgs)
+
+    expect(codAPIHandler.GetMatchInfo).toBeCalledTimes(3)
+    expect(dbHandler.updateReports).toBeCalledTimes(3)
+    expect(telegramSender.send).toBeCalledTimes(3)
+  })
+
+  test('#handler (match is reported for several channels)', async () => {
+    dbHandler.getCredentials = jest.fn().mockResolvedValueOnce(testSSO)
+    dbHandler.getReports = jest.fn().mockResolvedValueOnce([{
+      ... fakeStoredReport,
+      channels: [ 1, 2, 3, 4, 5 ],
+    }])
+    codAPIHandler.GetLastMatchId = jest.fn().mockResolvedValueOnce('OldMatchId')
+    codAPIHandler.GetMatchInfo = jest.fn().mockResolvedValueOnce([{
+      utcStartSeconds: 0,
+    }])
+
+    await reportLastMatchesCommand.handler(commandRequest, testArgs)
+
+    expect(codAPIHandler.GetMatchInfo).toBeCalledTimes(1)
+    expect(dbHandler.updateReports).toBeCalledTimes(1)
+    expect(telegramSender.send).toBeCalledTimes(5)
+  })
+})

--- a/tests/unit/spec/modules/telegramCommands/commands/lastMatchCommand.spec.ts
+++ b/tests/unit/spec/modules/telegramCommands/commands/lastMatchCommand.spec.ts
@@ -17,8 +17,8 @@ jest.mock('../../../../../../src/modules/telegramSender/telegramSender', () => {
 jest.mock('../../../../../../src/modules/codAPIHandler/codAPIHandler', () => {
   return {
     codAPIHandler: {
-      GetLastMatchId: jest.fn(),
-      GetMatchInfo: jest.fn(),
+      getLastMatchId: jest.fn(),
+      getMatchInfo: jest.fn(),
     },
   }
 })

--- a/tests/unit/spec/modules/telegramCommands/commands/lastMatchCommand.spec.ts
+++ b/tests/unit/spec/modules/telegramCommands/commands/lastMatchCommand.spec.ts
@@ -17,7 +17,8 @@ jest.mock('../../../../../../src/modules/telegramSender/telegramSender', () => {
 jest.mock('../../../../../../src/modules/codAPIHandler/codAPIHandler', () => {
   return {
     codAPIHandler: {
-      GetLastMatchInfo: jest.fn(),
+      GetLastMatchId: jest.fn(),
+      GetMatchInfo: jest.fn(),
     },
   }
 })
@@ -39,7 +40,7 @@ jest.mock('../../../../../../src/modules/dbHandler/dbHandler', () => {
   }
 })
 
-describe('LastMatchCommand', () => {
+describe('lastMatchCommand', () => {
   const testChatId = 98765
   const telegramCommandRequest = {
     command: '/FakeCommand',

--- a/tests/unit/spec/modules/telegramCommands/commands/registerUserReportsCommand.spec.ts
+++ b/tests/unit/spec/modules/telegramCommands/commands/registerUserReportsCommand.spec.ts
@@ -76,7 +76,7 @@ describe('registerUserReportsCommand', () => {
   test('#handler (invalid user)', async () => {
     dbHandler.isUserRegistered = jest.fn().mockResolvedValueOnce(false)
     dbHandler.getCredentials = jest.fn().mockResolvedValueOnce('FakeSSO')
-    codAPIHandler.GetUserSummary = jest.fn().mockResolvedValueOnce(undefined)
+    codAPIHandler.getUserSummary = jest.fn().mockResolvedValueOnce(undefined)
 
     const response = await registerUserReportsCommand.handler(
       telegramCommandRequest, [ '', '', 'FakeUser' ])
@@ -90,7 +90,7 @@ describe('registerUserReportsCommand', () => {
   test('#handler', async () => {
     dbHandler.isUserRegistered = jest.fn().mockResolvedValueOnce(false)
     dbHandler.getCredentials = jest.fn().mockResolvedValueOnce('FakeSSO')
-    codAPIHandler.GetUserSummary = jest.fn().mockResolvedValueOnce({
+    codAPIHandler.getUserSummary = jest.fn().mockResolvedValueOnce({
       data: {
         username: 'FakeUser',
       },

--- a/tests/unit/spec/modules/telegramCommands/commands/updateSSOCommand.spec.ts
+++ b/tests/unit/spec/modules/telegramCommands/commands/updateSSOCommand.spec.ts
@@ -42,7 +42,7 @@ describe('updateSSOCommand', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    codAPIHandler.IsValidSSO = jest.fn().mockResolvedValue(true)
+    codAPIHandler.isValidSSO = jest.fn().mockResolvedValue(true)
   })
 
   test('#validate (returns ok)', async () => {
@@ -81,7 +81,7 @@ describe('updateSSOCommand', () => {
   })
 
   test('#handler (invalid SSO)', async () => {
-    codAPIHandler.IsValidSSO = jest.fn().mockResolvedValue(false)
+    codAPIHandler.isValidSSO = jest.fn().mockResolvedValue(false)
 
     const response = await updateSSOCommand.handler(telegramCommandRequest, [])
 

--- a/tests/unit/spec/modules/telegramCommands/commands/updateSSOCommand.spec.ts
+++ b/tests/unit/spec/modules/telegramCommands/commands/updateSSOCommand.spec.ts
@@ -29,7 +29,7 @@ jest.mock('../../../../../../src/modules/configReader/configReader', () => {
   }
 })
 
-describe('UpdateSSOCommand', () => {
+describe('updateSSOCommand', () => {
   const telegramCommandRequest = {
     command: '/FakeCommand',
     source: {


### PR DESCRIPTION
The purpose of this PR is to add the scheduled reporting engine and functionality to report post-match reports to registered Telegram channels. 