### PR TITLE
Add session tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ To configure the application you have to set the following environment variables
 |-|-|
 | TELEGRAM_BOT_TOKEN | API token from your Telegram bot |
 | DATABASE_CONNECTION_STRING | Connection string to the MongoDB service |
-| ACCEPT_SSO_FROM | Accept SSO tokens only from the user specified here |
+| ACCEPT_SSO_FROM | Accept SSO tokens only of the user specified here |
 | MAX_REPORTS_PER_USER | Maximum reports to be sent per user at once. It is recommended not to use more than 4 |
 | ADMIN_COMMANDS | If some commands need admin privileges. Accepted values: `true` or `false` |
+| TIME_BETWEEN_SESSIONS | Time in minutes since the last game to report a user's session |
 
 Example:
 
@@ -36,6 +37,7 @@ DATABASE_CONNECTION_STRING=https://db8a89sd9keladsa.asd992klas.com/user=9384839
 ACCEPT_SSO_FROM=manoleitor#53781
 MAX_REPORTS_PER_USER=4
 ADMIN_COMMANDS=true
+TIME_BETWEEN_SESSIONS=90
 ```
 
 ## Telegram commands
@@ -51,16 +53,20 @@ These are the commands you can interact with using the Telegram bot.
 
 ## Scheduled reports
 
-Scheduled reports are events that are launched every X amount of time to perform periodic activities and their activation depends on the serverless platform where this project is deployed.
+Scheduled reports are events that are launched every X amount of time to perform periodic reports and their activation depends on the serverless platform where this project is deployed.
 
-The project is tested on AWS Lambda functions, but could be adapted to other types of serverless platforms by modifying the recipe for deployment without changing production code.
+To do this, we must first register the user whose gaming reports we want to receive using the `/RegisterUserReports <User>` command from one or more groups.
+
+The project is tested on AWS Lambda functions but could be adapted to other types of serverless platforms by modifying the recipe for deployment without changing the production code.
 
 ### Post-match results
 
 It is possible to receive the results of a match as soon as it is over on the desired channels.
 
-To do this, we must first register the user whose post-match results we want to receive using the `/RegisterUserReports <User>` command from one or more groups.
+If we want to enable this functionality, we just have to set the `postMatchReports` field to true on [serverless.yml](./serverless.yml) file.
 
-If we want to disable this functionality we just need to remove the `schedule` block corresponding to the `/ReportLastMatches` command from [serverless.yml](./serverless.yml).
+### Post-session report
 
-To modify the frequency for checking if there is new information of finished matches just modify the `rate` attribute.
+We can receive the gaming session overview when it has ended if we see the `sessionReports` field to true as mentioned in the previous paragraph.
+
+The amount of time that the engine waits until sending the session report is defined by the `TIME_BETWEEN_SESSIONS` environment variable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warzone-tracker",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "GPL-3.0",
   "description": "",
   "repository": {
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "axios": "^0.26.1",
+    "moment": "^2.29.3",
     "mongoose": "^6.2.7"
   },
   "devDependencies": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -14,6 +14,7 @@ provider:
     DATABASE_CONNECTION_STRING: ${env:DATABASE_CONNECTION_STRING}
     MAX_REPORTS_PER_USER: ${env:MAX_REPORTS_PER_USER}
     ADMIN_COMMANDS: ${env:ADMIN_COMMANDS}
+    TIME_BETWEEN_SESSIONS: ${env:TIME_BETWEEN_SESSIONS}
 
 package:
   individually: true
@@ -41,4 +42,5 @@ functions:
           rate: rate(1 minute)
           enabled: true
           input:
-            scheduleCommand: '/ReportLastMatches'
+            postMatchReports: true
+            sessionReports: true

--- a/src/models/schemas/UserReportsSchema.ts
+++ b/src/models/schemas/UserReportsSchema.ts
@@ -4,7 +4,9 @@ const UserReportsSchema = new Schema({
   user: { type: String, trim: true, unique: true, sparse: true },
   channels: [{ type: Number, trim: true, sparse: true }],
   lastMatch: { type: String, trim: true, sparse: true },
-  lastMatchTimestamp: { type: Number, trim: true, sparse: true },
+  lastMatchStartTimestamp: { type: Number, trim: true, sparse: true },
+  lastMatchEndTimestamp: { type: Number, trim: true, sparse: true },
+  sessionReported: { type: Boolean, trim: true, sparse: true },
 })
 
 export { UserReportsSchema }

--- a/src/models/types/UserReportsDoc.ts
+++ b/src/models/types/UserReportsDoc.ts
@@ -4,5 +4,7 @@ export interface UserReportsDoc extends mongoose.Document {
   user: { type: string, trim: true, unique: true, sparse: true },
   channels: [{ type: number, trim: true, sparse: true }],
   lastMatch: { type: string, trim: true, sparse: true },
-  lastMatchTimestamp: { type: number, trim: true, sparse: true },
+  lastMatchStartTimestamp: { type: number, trim: true, sparse: true },
+  lastMatchEndTimestamp: { type: number, trim: true, sparse: true },
+  sessionReported: { type: boolean, trim: true, sparse: true },
 }

--- a/src/modules/configReader/configReader.ts
+++ b/src/modules/configReader/configReader.ts
@@ -22,12 +22,17 @@ class ConfigReader {
       throw new Error('ADMIN_COMMANDS is undefined')
     }
 
+    if (!process.env.TIME_BETWEEN_SESSIONS) {
+      throw new Error('TIME_BETWEEN_SESSIONS is undefined')
+    }
+
     return {
       telegramBotToken: process.env.TELEGRAM_BOT_TOKEN as string,
       databaseConnectionString: process.env.DATABASE_CONNECTION_STRING as string,
       acceptSSOFrom: process.env.ACCEPT_SSO_FROM as string,
       maxReportsPerUser: process.env.MAX_REPORTS_PER_USER as unknown as number,
       adminCommands: process.env.ADMIN_COMMANDS == 'true',
+      timeBetweenSessions: process.env.TIME_BETWEEN_SESSIONS as unknown as number * 60,
     }
   }
 }

--- a/src/modules/configReader/types/Configuration.ts
+++ b/src/modules/configReader/types/Configuration.ts
@@ -5,4 +5,5 @@ export interface Configuration {
   acceptSSOFrom: string
   maxReportsPerUser: number
   adminCommands: boolean
+  timeBetweenSessions: number
 }

--- a/src/modules/formatters/telegramFormatter.ts
+++ b/src/modules/formatters/telegramFormatter.ts
@@ -1,10 +1,21 @@
 import { PlayerMatch } from '../codAPIHandler/types/PlayerMatch'
 import { gameModeDic } from './types/gameModeDic'
+import moment from 'moment'
 
 function getGameMode(rawMode: string): string {
   const mode = gameModeDic.get(rawMode)
 
   return mode ?? rawMode.replace(/_/g, '\\_')
+}
+
+function getDate(epoch: number): string {
+  return moment.utc(epoch).format('MMM Do YYYY, HH:mm:ss')
+}
+
+function getDateRange(epochFrom: number, epochTo: number): string {
+  return `${getDate(epochFrom)}\n\
+↓\n\
+${getDate(epochTo)}`
 }
 
 class TelegramFormatter {
@@ -19,10 +30,51 @@ class TelegramFormatter {
     })
 
     return `*//////////// Match ////////////*\n\
-(${new Date(mainPlayerInfo.utcStartSeconds * 1000).toUTCString()})\n\n\
+${getDate(mainPlayerInfo.utcStartSeconds * 1000)}\n\n\
 *Mode:* ${getGameMode(mainPlayerInfo.mode)}\n\
 *Position:* ${mainPlayerInfo.playerStats.teamPlacement}\n\n\
 ${playersReport}`
+  }
+
+  sessionReportFormatter(sessionMatches: PlayerMatch[]): string  {
+    let kdSum = 0
+    let killSum = 0
+    let assistSum = 0
+    let winSum = 0
+    let percentTimeMovingSum = 0
+    let matchesWithGulag = 0
+    let kdGulagSum = 0
+
+    sessionMatches.forEach(x => {
+      kdSum += x.playerStats.kdRatio
+      killSum += x.playerStats.kills
+      assistSum += x.playerStats.assists
+      winSum += x.playerStats.teamPlacement == 1 ? 1 : 0
+      percentTimeMovingSum += x.playerStats.percentTimeMoving
+      if (x.playerStats.gulagKills > 0 || x.playerStats.gulagDeaths > 0) {
+        matchesWithGulag++
+        kdGulagSum += x.playerStats.gulagDeaths == 0
+          ? x.playerStats.gulagKills
+          : x.playerStats.gulagKills / x.playerStats.gulagDeaths
+      }
+    })
+
+    const to = sessionMatches[0].utcEndSeconds * 1000
+    const from = sessionMatches[sessionMatches.length - 1].utcStartSeconds * 1000
+    const user = sessionMatches[0].player.username
+    const kd = Number(kdSum / sessionMatches.length).toFixed(2)
+    const kdGulag = Number(kdGulagSum / matchesWithGulag).toFixed(2)
+    const percentTimeMoving = Number(percentTimeMovingSum / sessionMatches.length).toFixed(2)
+
+    return `*//////////// ${user}'s session stats ////////////*\n\
+${getDateRange(from, to)}\n\n\
+*Wins:* ${winSum}\n\
+*Session KD:* ${kd}\n\
+${matchesWithGulag > 0 ? `*Session KD in Gulag:* ${kdGulag}\n` : ''}\
+*Kills:* ${killSum}\n\
+*Assists:* ${assistSum}\n\
+*Time moving:* ${percentTimeMoving}%\n\
+*Matches:* ${sessionMatches.length}\n`
   }
 }
 

--- a/src/modules/scheduledCommands/ScheduledCommandDispatcher.ts
+++ b/src/modules/scheduledCommands/ScheduledCommandDispatcher.ts
@@ -1,12 +1,44 @@
+import { UserReportsDoc } from '../../models/types/UserReportsDoc'
 import { CommandDispatcher } from '../commandDispatcher/CommandDispatcher'
+import { CommandRequest } from '../commandDispatcher/types/CommandRequest'
+import { CommandResponse } from '../commandDispatcher/types/CommandResponse'
+import { dbHandler } from '../dbHandler/dbHandler'
+import { MissingSSOToken } from '../telegramCommands/messages'
 import { reportLastMatchesCommand } from './commands/reportLastMatchesCommand'
+import { reportSessionCommand } from './commands/reportSessionCommand'
 
 const commandRegex = '^/([^ ]+)'
 
 export class ScheduledCommandDispatcher extends CommandDispatcher {
+  private ssoToken: string
+  private userReports: UserReportsDoc[]
+
   constructor() {
     super(commandRegex, [
       reportLastMatchesCommand,
+      reportSessionCommand,
     ])
+    this.ssoToken = ''
+    this.userReports = []
+  }
+
+  async init(): Promise<void> {
+    const sso = await dbHandler.getCredentials()
+
+    if (sso === undefined) {
+      throw new Error(MissingSSOToken)
+    }
+
+    this.ssoToken = sso.ssoToken as unknown as string
+    this.userReports = await dbHandler.getReports()
+  }
+
+  async dispatch(commandRequest: CommandRequest): Promise<CommandResponse> {
+    const scheduledCommandRequest = {
+      ... commandRequest,
+      ssoToken: this.ssoToken,
+      userReports: this.userReports,
+    }
+    return await super.dispatch(scheduledCommandRequest)
   }
 }

--- a/src/modules/scheduledCommands/commands/reportSessionCommand.ts
+++ b/src/modules/scheduledCommands/commands/reportSessionCommand.ts
@@ -1,0 +1,78 @@
+import { CodAPIHandler } from '../../codAPIHandler/CodAPIHandler'
+import { PlayerMatch } from '../../codAPIHandler/types/PlayerMatch'
+import { Command } from '../../commandDispatcher/types/Command'
+import { CommandRequest } from '../../commandDispatcher/types/CommandRequest'
+import { CommandResponse } from '../../commandDispatcher/types/CommandResponse'
+import { configReader } from '../../configReader/configReader'
+import { dbHandler } from '../../dbHandler/dbHandler'
+import { telegramFormatter } from '../../formatters/telegramFormatter'
+import { telegramHandler } from '../../telegramHandler/telegramHandler'
+import { ScheduledReportDone } from '../messages'
+import { ScheduledCommandRequest } from '../types/ScheduledCommandRequest'
+
+async function sendSessionReportViaTelegram(sessionMatches: PlayerMatch[], channels: number[]): Promise<void> {
+  const formattedSessionReport = telegramFormatter.sessionReportFormatter(sessionMatches)
+  const user = sessionMatches[0].player.username
+
+  const messagesSent = Array.from(channels, async channel => {
+    console.log(`Sending Telegram session report for ${user} in ${channel} channel`)
+    await telegramHandler.send(channel, formattedSessionReport)
+  })
+
+  await Promise.allSettled(messagesSent)
+}
+
+const reportSession = async (commandRequest: CommandRequest, args: string[]): Promise<CommandResponse> => {
+  const scheduledCommandRequest = commandRequest as ScheduledCommandRequest
+  const codAPIHandler = new CodAPIHandler(scheduledCommandRequest.ssoToken)
+  const timeBetweenSessions = configReader.getConfig().timeBetweenSessions
+
+  const sessionReportsSentForAllUser = Array.from(scheduledCommandRequest.userReports, async report => {
+    const sessionReported = report.sessionReported.valueOf() as boolean
+    const user = report.user.valueOf() as string
+    if (sessionReported) {
+      console.log(`The last session of ${user} has already been reported.`)
+      return
+    }
+
+    const endTimeLastMatch = report.lastMatchEndTimestamp.valueOf() as number
+    const now = new Date().getTime()
+    if (now - endTimeLastMatch < timeBetweenSessions) {
+      console.log(`${user}'s session cannot be reported yet`)
+      return
+    }
+
+    const sessionMatches = await codAPIHandler.getLastSessionMatches(user, timeBetweenSessions)
+    if (sessionMatches == undefined || sessionMatches.length == 0) {
+      console.error(`Could not get the session matches from ${user}`)
+      return
+    }
+
+    if (scheduledCommandRequest.sessionReports) {
+      const channels = report.channels.valueOf() as number[]
+      await sendSessionReportViaTelegram(sessionMatches, channels)
+    }
+
+    await dbHandler.updateSessionReport(report.user.valueOf() as string)
+  })
+
+  await Promise.allSettled(sessionReportsSentForAllUser)
+
+  return {
+    response: ScheduledReportDone,
+    success: true,
+  }
+}
+
+function validate(args: string[]): string {
+  return 'ok'
+}
+
+class ReportSessionCommand implements Command {
+  command = 'ReportSession'
+  handler = reportSession
+  argsValidation = validate
+}
+
+const reportSessionCommand = new ReportSessionCommand()
+export { reportSessionCommand }

--- a/src/modules/scheduledCommands/types/ScheduledCommandRequest.ts
+++ b/src/modules/scheduledCommands/types/ScheduledCommandRequest.ts
@@ -1,0 +1,9 @@
+import { UserReportsDoc } from '../../../models/types/UserReportsDoc'
+import { CommandRequest } from '../../commandDispatcher/types/CommandRequest'
+
+export interface ScheduledCommandRequest extends CommandRequest {
+  ssoToken: string
+  userReports: UserReportsDoc[]
+  postMatchReports: boolean
+  sessionReports: boolean
+}

--- a/src/modules/telegramCommands/commands/registerUserReportsCommand.ts
+++ b/src/modules/telegramCommands/commands/registerUserReportsCommand.ts
@@ -13,7 +13,8 @@ const register = async (commandRequest: CommandRequest, args: string[]): Promise
   const user = args[2]
   const request = commandRequest as TelegramCommandRequest
 
-  if (configReader.getConfig().adminCommands
+  if (request.source.type !== 'private'
+    && configReader.getConfig().adminCommands
     && !(await isAdmin(request.from.userId, request.source.chatId))) {
     return {
       response: UserMustBeAdmin,

--- a/tests/unit/spec/modules/configReader/configReader.spec.ts
+++ b/tests/unit/spec/modules/configReader/configReader.spec.ts
@@ -6,6 +6,7 @@ describe('configReader', () => {
   const testAcceptSSOFrom = 'TEST:ACCEPT-SSO-FROM'
   const testMaxReportsPerUser = '3'
   const testAdminCommands = 'true'
+  const testTimeBetweenSessions = '2'
 
   beforeEach(() => {
     process.env.TELEGRAM_BOT_TOKEN = testBotToken
@@ -13,6 +14,7 @@ describe('configReader', () => {
     process.env.ACCEPT_SSO_FROM = testAcceptSSOFrom
     process.env.MAX_REPORTS_PER_USER = testMaxReportsPerUser
     process.env.ADMIN_COMMANDS = testAdminCommands
+    process.env.TIME_BETWEEN_SESSIONS = testTimeBetweenSessions
   })
 
   test('#getConfig', async () => {
@@ -24,6 +26,7 @@ describe('configReader', () => {
       acceptSSOFrom: testAcceptSSOFrom,
       maxReportsPerUser: testMaxReportsPerUser,
       adminCommands: true,
+      timeBetweenSessions: 120,
     })
   })
 
@@ -79,6 +82,17 @@ describe('configReader', () => {
       expect(1).toBe(0)
     } catch (error: any) {
       expect(error.message).toBe('ADMIN_COMMANDS is undefined')
+    }
+  })
+
+  test('#getConfig (TIME_BETWEEN_SESSIONS undefined)', async () => {
+    try {
+      delete process.env.TIME_BETWEEN_SESSIONS
+      configReader.getConfig()
+
+      expect(1).toBe(0)
+    } catch (error: any) {
+      expect(error.message).toBe('TIME_BETWEEN_SESSIONS is undefined')
     }
   })
 })

--- a/tests/unit/spec/modules/dbHandler/dbHandler.spec.ts
+++ b/tests/unit/spec/modules/dbHandler/dbHandler.spec.ts
@@ -118,11 +118,13 @@ describe('dbHandler', () => {
   })
 
   test('#updateReports', async () => {
-    await dbHandler.updateReports(testUserReport, 'FakeMatchId', 989)
+    await dbHandler.updateReports(testUserReport, 'FakeMatchId', 989, 1003)
 
     expect(UserReportsModel.findByIdAndUpdate).toBeCalledWith(testUserReport.id, {
       lastMatch: 'FakeMatchId',
-      lastMatchTimestamp: 989,
+      lastMatchStartTimestamp: 989,
+      lastMatchEndTimestamp: 1003,
+      sessionReported: false,
     })
   })
 

--- a/tests/unit/spec/modules/formatters/telegramFormatter.spec.ts
+++ b/tests/unit/spec/modules/formatters/telegramFormatter.spec.ts
@@ -37,7 +37,7 @@ describe('telegramFormatter', () => {
 
     expect(matchFormatted).toBe(
       '*//////////// Match ////////////*\n' +
-      '(Thu, 31 Mar 2022 15:26:34 GMT)\n\n' +
+      'Mar 31st 2022, 15:26:34\n\n' +
 
       '*Mode:* BR Trios\n' +
       '*Position:* 6\n\n' +
@@ -55,7 +55,7 @@ describe('telegramFormatter', () => {
 
     expect(matchFormatted).toBe(
       '*//////////// Match ////////////*\n' +
-      '(Thu, 31 Mar 2022 15:26:34 GMT)\n\n' +
+      'Mar 31st 2022, 15:26:34\n\n' +
 
       '*Mode:* unexpected\\_mode\n' +
       '*Position:* 6\n\n' +

--- a/tests/unit/spec/modules/scheduledCommands/ScheduledCommandDispatcher.spec.ts
+++ b/tests/unit/spec/modules/scheduledCommands/ScheduledCommandDispatcher.spec.ts
@@ -1,6 +1,7 @@
 import { CommandDispatcher } from '../../../../../src/modules/commandDispatcher/CommandDispatcher'
 import { ScheduledCommandDispatcher } from '../../../../../src/modules/scheduledCommands/ScheduledCommandDispatcher'
 import { reportLastMatchesCommand } from '../../../../../src/modules/scheduledCommands/commands/reportLastMatchesCommand'
+import { reportSessionCommand } from '../../../../../src/modules/scheduledCommands/commands/reportSessionCommand'
 
 jest.mock('../../../../../src/modules/commandDispatcher/CommandDispatcher')
 
@@ -18,6 +19,7 @@ describe('ScheduledCommandDispatcher', () => {
   const scheduledCommandRegex = '^/([^ ]+)'
   const scheduledCommands = [
     reportLastMatchesCommand,
+    reportSessionCommand,
   ]
 
   test('Parent constructor is called using the expected commands', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4546,6 +4546,11 @@ moment-timezone@^0.5.31:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
+moment@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
+  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
+
 mongodb-connection-string-url@^2.4.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.2.tgz#f075c8d529e8d3916386018b8a396aed4f16e5ed"


### PR DESCRIPTION
The purpose of this PR is to add the possibility of configuring session reports, where a gaming session is a set of consecutive matches.

